### PR TITLE
chore(server): use native unsecured http2 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module main
 
-go 1.22
+go 1.24
 
 require (
 	firebase.google.com/go/v4 v4.15.1
-	golang.org/x/net v0.34.0
 	google.golang.org/api v0.211.0
 )
 
@@ -35,6 +34,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.29.0 // indirect
 	go.opentelemetry.io/otel/trace v1.29.0 // indirect
 	golang.org/x/crypto v0.32.0 // indirect
+	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/oauth2 v0.24.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ func main() {
 
 	resolveAccessOrigins()
 
-	protocols = new(http.Protocols)
+	protocols := new(http.Protocols)
 	protocols.SetHTTP1(true)
 	protocols.SetUnencryptedHTTP2(true)
 	server := &http.Server{

--- a/main.go
+++ b/main.go
@@ -5,9 +5,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 )
 
 var accessOrigins = map[string]struct{}{}
@@ -22,12 +19,16 @@ func main() {
 	resolveAccessOrigins()
 
 	handler := http.HandlerFunc(ServeHTTP)
-	h1s := &http.Server{
-		Addr:    ":" + port,
-		Handler: h2c.NewHandler(handler, &http2.Server{}),
+	protocols = new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
+	server := &http.Server{
+		Addr:      ":" + port,
+		Handler:   handler,
+		Protocols: protocols,
 	}
 
-	if err := h1s.ListenAndServe(); err != nil {
+	if err := server.ListenAndServe(); err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -18,13 +18,12 @@ func main() {
 
 	resolveAccessOrigins()
 
-	handler := http.HandlerFunc(ServeHTTP)
 	protocols = new(http.Protocols)
 	protocols.SetHTTP1(true)
 	protocols.SetUnencryptedHTTP2(true)
 	server := &http.Server{
 		Addr:      ":" + port,
-		Handler:   handler,
+		Handler:   http.HandlerFunc(ServeHTTP),
 		Protocols: protocols,
 	}
 


### PR DESCRIPTION
Go 1.24 has added the support of [UnencryptedHTTP2](https://tip.golang.org/doc/go1.24).